### PR TITLE
Revert "Change protocol ID to start from 1"

### DIFF
--- a/src/dump-wallet-addresses.ts
+++ b/src/dump-wallet-addresses.ts
@@ -34,7 +34,8 @@ function main() {
               const sponsorWallet = {
                 beaconName,
                 walletType: 'Sponsor wallet',
-                address: deriveSponsorWalletAddress(apiMetadata.xpub, 1, beaconChain.sponsor),
+                // The `protocolId` below will be 1 and not 0 in v0.4
+                address: deriveSponsorWalletAddress(apiMetadata.xpub, 0, beaconChain.sponsor),
                 thresholdInWei: ethers.utils
                   .parseUnits(
                     beaconChain.sponsorWalletBalanceAlertThreshold.amount.toString(),


### PR DESCRIPTION
Since we are using Airnode v0.3.1 for the hackathon, but the protocol ID
change only impacts v0.4 it makes sense to revert this change for now.

More context:
https://api3workspace.slack.com/archives/C02UW1M157A/p1643374411080499
https://api3workspace.slack.com/archives/C02UW1M157A/p1643400674818389

This reverts commit f44c8a06912f68991d89eecf253d98c3907c3580.