### PR TITLE
Add templateUrl to documentation payload

### DIFF
--- a/data/documentation.json
+++ b/data/documentation.json
@@ -5,14 +5,14 @@
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 0.1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
-        "templateUrl": "https://github.com/api3dao/operations/blob/main/data/apis/api3/templates/coingecko btc_usd.json",
+        "templateUrl": "https://github.com/api3dao/operations/blob/fa18bac5ceb1dbb894fb095a43674fe1d366e125/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": ["ropsten-2"]
       },
       {
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
-        "templateUrl": "https://github.com/api3dao/operations/blob/main/data/apis/api3/templates/coingecko btc_usd.json",
+        "templateUrl": "https://github.com/api3dao/operations/blob/fa18bac5ceb1dbb894fb095a43674fe1d366e125/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": ["ropsten"]
       }
     ]

--- a/data/documentation.json
+++ b/data/documentation.json
@@ -5,12 +5,14 @@
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 0.1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
+        "templateUrl": "https://github.com/api3dao/operations/blob/main/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": ["ropsten-2"]
       },
       {
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
+        "templateUrl": "https://github.com/api3dao/operations/blob/main/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": ["ropsten"]
       }
     ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface BeaconDocumentation {
   description: string;
   oisTitle: string;
   decodedParameters: ApiCallParameters[];
+  templateUrl: string;
   chains: string[];
 }
 

--- a/src/utils/normalization.ts
+++ b/src/utils/normalization.ts
@@ -98,6 +98,9 @@ export const normalize = (payload: OperationsRepository) => {
               beaconId: beacon.beaconId,
               name: beacon.name,
               description: beacon.description,
+              templateUrl: `https://github.com/api3dao/operations/blob/main/data/apis/api3/templates/${
+                Object.entries(api.templates).find(([_key, template]) => template.templateId === beacon.templateId)[0]
+              }.json`,
               chains: beacon.chains.map((chain) => chain.name),
             })),
         ])

--- a/src/utils/normalization.ts
+++ b/src/utils/normalization.ts
@@ -85,6 +85,8 @@ export const normalize = (payload: OperationsRepository) => {
     })
   );
 
+  const shaHash = require('child_process').execSync('git rev-parse HEAD').toString().trim();
+
   // TODO break this up
   const documentation = {
     beacons: Object.fromEntries(
@@ -98,7 +100,7 @@ export const normalize = (payload: OperationsRepository) => {
               beaconId: beacon.beaconId,
               name: beacon.name,
               description: beacon.description,
-              templateUrl: `https://github.com/api3dao/operations/blob/main/data/apis/api3/templates/${
+              templateUrl: `https://github.com/api3dao/operations/blob/${shaHash}/data/apis/api3/templates/${
                 Object.entries(api.templates).find(([_key, template]) => template.templateId === beacon.templateId)[0]
               }.json`,
               chains: beacon.chains.map((chain) => chain.name),


### PR DESCRIPTION
This PR adds a templateUrl to the documentation export, which is a link to the template file in the ops repository on Github.
The links are keyed to the commit that generated them, effectively creating "permalinks" (a particular documentation.json payload will always reference files in its own commit).