### PR TITLE
BEC-52 | Register subscriptionIds onchain 

### DIFF
--- a/credentials.example.json
+++ b/credentials.example.json
@@ -1,0 +1,170 @@
+{
+  "etherscan": {
+    "apiKey": {
+      "mainnet": "",
+      "ropsten": "",
+      "rinkeby": "",
+      "goerli": "",
+      "kovan": "",
+      "arbitrumOne": "<arbitrum>",
+      "arbitrumTestnet": "<arbitrum-testnet>",
+      "avalanche": "",
+      "avalancheFujiTestnet": "<avalanche-testnet>",
+      "bsc": "",
+      "bscTestnet": "<bsc-testnet>",
+      "opera": "<fantom>",
+      "ftmTestnet": "<fantom-testnet>",
+      "xdai": "<gnosis>PLACEHOLDER",
+      "sokol": "<gnosis-testnet>PLACEHOLDER",
+      "moonbeam": "",
+      "moonbaseAlpha": "<moonbeam-testnet>",
+      "moonriver": "",
+      "optimisticEthereum": "<optimism>",
+      "optimisticKovan": "<optimism-testnet>",
+      "polygon": "",
+      "polygonMumbai": "<polygon-testnet>"
+    }
+  },
+  "networks": {
+    "mainnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 1,
+      "url": "https://mainnet.infura.io/v3/8997be2479d94f91a24df8b56a8e98df"
+    },
+    "ropsten": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 3,
+      "url": "https://ropsten.infura.io/v3/8997be2479d94f91a24df8b56a8e98df"
+    },
+    "rinkeby": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 4,
+      "url": "https://rinkeby.infura.io/v3/8997be2479d94f91a24df8b56a8e98df"
+    },
+    "goerli": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 5,
+      "url": "https://goerli.infura.io/v3/8997be2479d94f91a24df8b56a8e98df"
+    },
+    "kovan": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 42,
+      "url": "https://kovan.infura.io/v3/8997be2479d94f91a24df8b56a8e98df"
+    },
+    "arbitrum": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 42161,
+      "url": "https://arb1.arbitrum.io/rpc"
+    },
+    "arbitrum-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 421611,
+      "url": "https://rinkeby.arbitrum.io/rpc"
+    },
+    "avalanche": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 43114,
+      "url": "https://api.avax.network/ext/bc/C/rpc"
+    },
+    "avalanche-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 43113,
+      "url": "https://api.avax-test.network/ext/bc/C/rpc"
+    },
+    "bsc": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 56,
+      "url": "https://bsc-dataseed.binance.org"
+    },
+    "bsc-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 97,
+      "url": "https://data-seed-prebsc-1-s1.binance.org:8545/"
+    },
+    "fantom": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 250,
+      "url": "https://rpcapi.fantom.network/"
+    },
+    "fantom-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 4002,
+      "url": "https://rpc.testnet.fantom.network/"
+    },
+    "gnosis": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 100,
+      "url": "https://rpc.gnosischain.com"
+    },
+    "gnosis-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 77,
+      "url": "https://sokol.poa.network"
+    },
+    "metis": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 1088,
+      "url": "https://andromeda.metis.io/?owner=1088"
+    },
+    "metis-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 588,
+      "url": "https://stardust.metis.io/?owner=588"
+    },
+    "milkomeda": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 2001,
+      "url": "https://rpc-mainnet-cardano-evm.c1.milkomeda.com"
+    },
+    "milkomeda-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 200101,
+      "url": "https://rpc-devnet-cardano-evm.c1.milkomeda.com"
+    },
+    "moonbeam": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 1284,
+      "url": "https://rpc.api.moonbeam.network"
+    },
+    "moonbeam-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 1287,
+      "url": "https://rpc.api.moonbase.moonbeam.network"
+    },
+    "moonriver": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 1285,
+      "url": "https://rpc.api.moonriver.moonbeam.network"
+    },
+    "optimism": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 10,
+      "url": "https://mainnet.optimism.io"
+    },
+    "optimism-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 69,
+      "url": "https://kovan.optimism.io"
+    },
+    "polygon": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 137,
+      "url": "https://polygon-rpc.com/"
+    },
+    "polygon-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 80001,
+      "url": "https://rpc-mumbai.matic.today"
+    },
+    "rsk": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 30,
+      "url": "https://public-node.rsk.co"
+    },
+    "rsk-testnet": {
+      "accounts": { "mnemonic": "" },
+      "chainId": 31,
+      "url": "https://public-node.testnet.rsk.co"
+    }
+  }
+}

--- a/data/documentation.json
+++ b/data/documentation.json
@@ -5,7 +5,7 @@
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 0.1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
-        "templateUrl": "https://github.com/api3dao/operations/blob/f265017e671794ee0c5f3461a926b95f93c9a812/data/apis/api3/templates/coingecko btc_usd.json",
+        "templateUrl": "https://github.com/api3dao/operations/blob/59dc6acaea0d3c0c94b9fe1561f8ac9fcbe0405b/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": ["ropsten"]
       }
     ]

--- a/data/documentation.json
+++ b/data/documentation.json
@@ -5,7 +5,7 @@
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 0.1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
-        "templateUrl": "https://github.com/api3dao/operations/blob/65ab2e5fea76043e402058094f9bd0a37bec2b55/data/apis/api3/templates/coingecko btc_usd.json",
+        "templateUrl": "https://github.com/api3dao/operations/blob/579f2b81133ea1bf52a3de0f31f92cf85016e37c/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": ["ropsten"]
       }
     ]

--- a/data/documentation.json
+++ b/data/documentation.json
@@ -5,7 +5,7 @@
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 0.1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
-        "templateUrl": "https://github.com/api3dao/operations/blob/2a0c4d355e82438561f5b1dab000e28db9e04433/data/apis/api3/templates/coingecko btc_usd.json",
+        "templateUrl": "https://github.com/api3dao/operations/blob/f265017e671794ee0c5f3461a926b95f93c9a812/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": ["ropsten"]
       }
     ]

--- a/data/documentation.json
+++ b/data/documentation.json
@@ -5,7 +5,7 @@
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 0.1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
-        "templateUrl": "https://github.com/api3dao/operations/blob/59dc6acaea0d3c0c94b9fe1561f8ac9fcbe0405b/data/apis/api3/templates/coingecko btc_usd.json",
+        "templateUrl": "https://github.com/api3dao/operations/blob/ada2ddcb0a0d0877d5a36cab169abc2a3e439baa/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": ["ropsten"]
       }
     ]

--- a/data/documentation.json
+++ b/data/documentation.json
@@ -5,7 +5,7 @@
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 0.1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
-        "templateUrl": "https://github.com/api3dao/operations/blob/0c9c36a7b574752cfda6b3f397d04a5dddb5a4fb/data/apis/api3/templates/coingecko btc_usd.json",
+        "templateUrl": "https://github.com/api3dao/operations/blob/65ab2e5fea76043e402058094f9bd0a37bec2b55/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": ["ropsten"]
       }
     ]

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jest": "^25.3.0",
     "ethers": "^5.5.2",
+    "@ethersproject/experimental": "5.6.0",
     "husky": "^7.0.4",
     "jest": "^27.4.5",
     "prettier": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "deploy-airkeeper": "yarn ts-node src/deploy-airkeeper",
     "deploy-airnode": "yarn ts-node src/deploy-airnode",
     "generate-gateway-key": "ts-node src/generate-gateway-key.ts",
+    "register-subscriptions": "ts-node src/register-subscriptions.ts",
     "build": "yarn run clean && yarn run compile",
     "clean": "rimraf -rf ./dist *.tgz",
     "compile": "tsc -p tsconfig.json",

--- a/src/register-subscriptions.ts
+++ b/src/register-subscriptions.ts
@@ -1,16 +1,11 @@
 import { ethers } from 'ethers';
+import { NonceManager } from '@ethersproject/experimental';
 import { Choice, PromptObject } from 'prompts';
 import { encode } from '@api3/airnode-abi';
-import { AirnodeRrpAddresses, RequesterAuthorizerWithAirnodeAddresses } from '@api3/airnode-protocol';
-import { deriveEndpointId } from '@api3/airnode-admin';
-import { OperationsRepository } from './types';
 import { promptQuestions } from './utils/prompts';
 import { readOperationsRepository } from './utils/read-operations';
-import { writeOperationsRepository } from './utils/write-operations';
 import { runAndHandleErrors } from './utils/cli';
 import { chainNameToChainId, chainNameToPublicRPCUrl, DapiServerContract, DapiServerInterface } from './utils/evm';
-import { NonceManager } from '@ethersproject/experimental';
-import { sanitiseFilename } from './utils/filesystem';
 
 const questions = (choices: Choice[]): PromptObject[] => {
   return [
@@ -103,6 +98,7 @@ const main = async () => {
         )
       );
 
+      // eslint-disable-next-line no-async-promise-executor
       return new Promise(async (resolve, reject) => {
         try {
           console.log(`🔗 Registering subscriptionId for beacon ${beaconName} on chain ${chain.name}`);

--- a/src/register-subscriptions.ts
+++ b/src/register-subscriptions.ts
@@ -1,0 +1,153 @@
+import { ethers } from 'ethers';
+import { Choice, PromptObject } from 'prompts';
+import { encode } from '@api3/airnode-abi';
+import { AirnodeRrpAddresses, RequesterAuthorizerWithAirnodeAddresses } from '@api3/airnode-protocol';
+import { deriveEndpointId } from '@api3/airnode-admin';
+import { OperationsRepository } from './types';
+import { promptQuestions } from './utils/prompts';
+import { readOperationsRepository } from './utils/read-operations';
+import { writeOperationsRepository } from './utils/write-operations';
+import { runAndHandleErrors } from './utils/cli';
+import { chainNameToChainId, chainNameToPublicRPCUrl, DapiServerContract, DapiServerInterface } from './utils/evm';
+import { NonceManager } from '@ethersproject/experimental';
+import { sanitiseFilename } from './utils/filesystem';
+
+const questions = (choices: Choice[]): PromptObject[] => {
+  return [
+    {
+      type: 'text',
+      name: 'mnemonic',
+      message: 'Enter the mnemonic that will be used to make the transaction for registering the subscription Ids',
+      initial: '',
+    },
+    {
+      type: 'autocomplete',
+      name: 'apiName',
+      message: 'For which API integration do you need to register subscriptionIds for?',
+      choices: choices,
+    },
+  ];
+};
+
+const main = async () => {
+  const operationsRepository = readOperationsRepository();
+  const apiChoices = Object.keys(operationsRepository.apis).map((api) => ({ title: api, value: api }));
+  const response = await promptQuestions(questions(apiChoices));
+  const apiData = operationsRepository.apis[response.apiName];
+
+  if (!response.mnemonic) throw new Error('🛑 No mnemonic provided');
+  const registrar = ethers.Wallet.fromMnemonic(response.mnemonic);
+
+  // Get all the chains the API will be deployed on
+  const apiChains = [
+    ...new Set(Object.values(apiData.beacons).flatMap((beacon) => beacon.chains.map((chain) => chain.name))),
+  ];
+
+  // Build NounceManagers for each chain
+  const nonceManagers = apiChains.reduce(
+    (acc, chainName) => ({
+      ...acc,
+      [chainName]: new NonceManager(
+        registrar.connect(new ethers.providers.JsonRpcProvider(chainNameToPublicRPCUrl[chainName]))
+      ),
+    }),
+    {} as { [chainName: string]: NonceManager }
+  );
+
+  const subscriptionPromises = Object.entries(apiData.beacons).flatMap(([beaconName, beacon]) => {
+    const DapiServerInteface = DapiServerInterface();
+    const parameters = '0x';
+    const airnodeAddress = beacon.airnodeAddress;
+    const templateId = beacon.templateId;
+    const threshold = ethers.BigNumber.from(100000000)
+      .mul(beacon.updateConditionPercentage * 100)
+      .div(10000);
+    const beaconUpdateSubscriptionConditionParameters = ethers.utils.defaultAbiCoder.encode(['uint256'], [threshold]);
+    const encodedBeaconUpdateSubscriptionConditions = encode([
+      {
+        type: 'bytes32',
+        name: '_conditionFunctionId',
+        value: ethers.utils.defaultAbiCoder.encode(
+          ['bytes4'],
+          [DapiServerInteface.getSighash('conditionPspBeaconUpdate')]
+        ),
+      },
+      { type: 'bytes', name: '_conditionParameters', value: beaconUpdateSubscriptionConditionParameters },
+    ]);
+    return beacon.chains.map(async (chain) => {
+      const chainId = chainNameToChainId[chain.name];
+      if (!chainId) throw new Error(`🛑 Unknown chain name: ${chain.name}`);
+
+      if (!chainNameToPublicRPCUrl[chain.name]) throw new Error(`🛑 No public RPC URL for chain ${chain.name}`);
+      const provider = new ethers.providers.JsonRpcProvider(chainNameToPublicRPCUrl[chain.name]);
+      const DapiServerAddress = operationsRepository.documentation.chains[chain.name].contracts['DapiServer'];
+      if (!DapiServerAddress) throw new Error(`🛑 No DapiServer contract address for chain ${chain.name}`);
+      const DapiServer = DapiServerContract(DapiServerAddress, provider);
+
+      const sponsor = chain.sponsor;
+
+      const expectedSubscriptionId = ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'address', 'bytes32', 'bytes', 'bytes', 'address', 'address', 'address', 'bytes4'],
+          [
+            chainId,
+            airnodeAddress,
+            templateId,
+            parameters,
+            encodedBeaconUpdateSubscriptionConditions,
+            airnodeAddress,
+            sponsor,
+            DapiServerAddress,
+            DapiServerInteface.getSighash('fulfillPspBeaconUpdate'),
+          ]
+        )
+      );
+
+      return new Promise(async (resolve, reject) => {
+        try {
+          console.log(`🔗 Registering subscriptionId for beacon ${beaconName} on chain ${chain.name}`);
+
+          const registerBeaconUpdateSubscription = await DapiServer.connect(
+            nonceManagers[chain.name]
+          ).registerBeaconUpdateSubscription(
+            airnodeAddress,
+            templateId,
+            encodedBeaconUpdateSubscriptionConditions,
+            airnodeAddress,
+            sponsor
+          );
+
+          // Check that the transaction is complete
+          const tx = await registerBeaconUpdateSubscription.wait();
+
+          const subscriptionId = tx.events.find(
+            (event: { event: string }) => event.event === 'RegisteredBeaconUpdateSubscription'
+          ).args.subscriptionId;
+
+          if (subscriptionId !== expectedSubscriptionId) {
+            reject(`🛑 The subscription ID ${subscriptionId} does not match the expected ID ${expectedSubscriptionId}`);
+          }
+
+          resolve(
+            `✅ Subscription registered with ID ${subscriptionId} for beacon ${beaconName} on chain ${chain.name}`
+          );
+        } catch (error) {
+          console.error(`🛑 Error registering subscription for beacon ${beaconName} on chain ${chain.name}`);
+          reject(error);
+        }
+      });
+    });
+  });
+
+  await Promise.allSettled(subscriptionPromises).then((results) => {
+    results.forEach((result) => {
+      if (result.status === 'fulfilled') {
+        console.log(result.value);
+      } else {
+        console.log(result.reason);
+      }
+    });
+  });
+};
+
+runAndHandleErrors(main);

--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -13,7 +13,23 @@ export const chainNameToChainId: { [chainName: string]: number } = {
   fantom: 250,
 };
 
+export const chainNameToPublicRPCUrl: { [chainName: string]: string } = {
+  mainnet: 'https://rpc.ankr.com/eth',
+  ropsten: 'https://ropsten.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
+  rinkeby: 'https://rinkeby.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
+  kovan: 'https://kovan.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
+  goerli: 'https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
+  polygon: 'https://polygon-rpc.com/',
+  polygonMumbai: 'https://rpc-mumbai.matic.today',
+  fantom: 'https://rpc.ftm.tools/',
+};
+
 export const DapiServerInterface = () => {
   const dapiServerAbi = JSON.parse(fs.readFileSync(path.resolve('./src/utils/artifacts/DapiServer.json')).toString());
   return new ethers.utils.Interface(dapiServerAbi.abi);
+};
+
+export const DapiServerContract = (dapiServerAddress: string, provider: ethers.providers.JsonRpcProvider) => {
+  const dapiServerAbi = JSON.parse(fs.readFileSync(path.resolve('./src/utils/artifacts/DapiServer.json')).toString());
+  return new ethers.Contract(dapiServerAddress, dapiServerAbi.abi, provider);
 };

--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -13,17 +13,6 @@ export const chainNameToChainId: { [chainName: string]: number } = {
   fantom: 250,
 };
 
-export const chainNameToPublicRPCUrl: { [chainName: string]: string } = {
-  mainnet: 'https://rpc.ankr.com/eth',
-  ropsten: 'https://ropsten.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
-  rinkeby: 'https://rinkeby.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
-  kovan: 'https://kovan.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
-  goerli: 'https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
-  polygon: 'https://polygon-rpc.com/',
-  polygonMumbai: 'https://rpc-mumbai.matic.today',
-  fantom: 'https://rpc.ftm.tools/',
-};
-
 export const DapiServerInterface = () => {
   const dapiServerAbi = JSON.parse(fs.readFileSync(path.resolve('./src/utils/artifacts/DapiServer.json')).toString());
   return new ethers.utils.Interface(dapiServerAbi.abi);

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'fs';
+
 export const sanitiseFilename = (filename: string) => {
   const illegalRe = /[\/?<>\\:*|"]/g;
   // eslint-disable-next-line no-control-regex
@@ -11,4 +13,12 @@ export const sanitiseFilename = (filename: string) => {
     .replace(reservedRe, '_')
     .replace(windowsReservedRe, '_')
     .toLocaleLowerCase();
+};
+
+export const loadCredentials = () => {
+  let credentials = require('../../credentials.example.json');
+  if (existsSync('../../credentials.json')) {
+    credentials = require('../../credentials.json');
+  }
+  return credentials;
 };

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -16,9 +16,8 @@ export const sanitiseFilename = (filename: string) => {
 };
 
 export const loadCredentials = () => {
-  let credentials = require('../../credentials.example.json');
   if (existsSync('../../credentials.json')) {
-    credentials = require('../../credentials.json');
+    return require('../../credentials.json');
   }
-  return credentials;
+  return require('../../credentials.example.json');
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,6 +418,21 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
+"@ethersproject/abi@5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.1.tgz#f7de888edeb56b0a657b672bdd1b3a1135cd14f7"
+  integrity sha512-0cqssYh6FXjlwKWBmLm3+zH2BNARoS5u/hxbz+LpQmcDB3w0W553h2btWui1/uZp2GBM/SI3KniTuMcYyHpA5w==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/abstract-provider@5.6.0", "@ethersproject/abstract-provider@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz#0c4ac7054650dbd9c476cf5907f588bbb6ef3061"
@@ -507,6 +522,15 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.0"
 
+"@ethersproject/experimental@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/experimental/-/experimental-5.6.0.tgz#c72ef00a79b746c522eb79736712169d71c55f64"
+  integrity sha512-lSEM/6t+BicbeyRxat5meoQhXZLoBEziVrxZqeCIhsPntvq4DlMobPBKXF0Iz3m0dMvl9uga7fHEO4YD9SgCgw==
+  dependencies:
+    "@ethersproject/web" "^5.6.0"
+    ethers "^5.6.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/hash@5.6.0", "@ethersproject/hash@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
@@ -578,6 +602,13 @@
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
+"@ethersproject/networks@5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.6.2.tgz#2bacda62102c0b1fcee408315f2bed4f6fbdf336"
+  integrity sha512-9uEzaJY7j5wpYGTojGp8U89mSsgQLc40PCMJLMCnFXTs7nhBveZ0t7dbqWUNrepWTszDbFkYD6WlL8DKx5huHA==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/pbkdf2@5.6.0", "@ethersproject/pbkdf2@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz#04fcc2d7c6bff88393f5b4237d906a192426685a"
@@ -597,6 +628,31 @@
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.6.2.tgz#b9807b1c8c6f59fa2ee4b3cf6519724d07a9f422"
   integrity sha512-6/EaFW/hNWz+224FXwl8+HdMRzVHt8DpPmu5MZaIQqx/K/ELnC9eY236SMV7mleCM3NnEArFwcAAxH5kUUgaRg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
+"@ethersproject/providers@5.6.4":
+  version "5.6.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.6.4.tgz#1a49c211b57b0b2703c320819abbbfa35c83dff7"
+  integrity sha512-WAdknnaZ52hpHV3qPiJmKx401BLpup47h36Axxgre9zT+doa/4GC/Ne48ICPxTm0BqndpToHjpLP1ZnaxyE+vw==
   dependencies:
     "@ethersproject/abstract-provider" "^5.6.0"
     "@ethersproject/abstract-signer" "^5.6.0"
@@ -2119,6 +2175,42 @@ ethers@^5.4.5, ethers@^5.5.2:
     "@ethersproject/pbkdf2" "5.6.0"
     "@ethersproject/properties" "5.6.0"
     "@ethersproject/providers" "5.6.2"
+    "@ethersproject/random" "5.6.0"
+    "@ethersproject/rlp" "5.6.0"
+    "@ethersproject/sha2" "5.6.0"
+    "@ethersproject/signing-key" "5.6.0"
+    "@ethersproject/solidity" "5.6.0"
+    "@ethersproject/strings" "5.6.0"
+    "@ethersproject/transactions" "5.6.0"
+    "@ethersproject/units" "5.6.0"
+    "@ethersproject/wallet" "5.6.0"
+    "@ethersproject/web" "5.6.0"
+    "@ethersproject/wordlists" "5.6.0"
+
+ethers@^5.6.0:
+  version "5.6.4"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.4.tgz#23629e9a7d4bc5802dfb53d4da420d738744b53c"
+  integrity sha512-62UIfxAQXdf67TeeOaoOoPctm5hUlYgfd0iW3wxfj7qRYKDcvvy0f+sJ3W2/Pyx77R8dblvejA8jokj+lS+ATQ==
+  dependencies:
+    "@ethersproject/abi" "5.6.1"
+    "@ethersproject/abstract-provider" "5.6.0"
+    "@ethersproject/abstract-signer" "5.6.0"
+    "@ethersproject/address" "5.6.0"
+    "@ethersproject/base64" "5.6.0"
+    "@ethersproject/basex" "5.6.0"
+    "@ethersproject/bignumber" "5.6.0"
+    "@ethersproject/bytes" "5.6.1"
+    "@ethersproject/constants" "5.6.0"
+    "@ethersproject/contracts" "5.6.0"
+    "@ethersproject/hash" "5.6.0"
+    "@ethersproject/hdnode" "5.6.0"
+    "@ethersproject/json-wallets" "5.6.0"
+    "@ethersproject/keccak256" "5.6.0"
+    "@ethersproject/logger" "5.6.0"
+    "@ethersproject/networks" "5.6.2"
+    "@ethersproject/pbkdf2" "5.6.0"
+    "@ethersproject/properties" "5.6.0"
+    "@ethersproject/providers" "5.6.4"
     "@ethersproject/random" "5.6.0"
     "@ethersproject/rlp" "5.6.0"
     "@ethersproject/sha2" "5.6.0"


### PR DESCRIPTION
This script allows for the subscriptionIds to be registered on chain. Its done in parallel which should make this pretty fast to instantly register for all beacons across all chains.         
       
I've tested it by registering multiple subsciptionIds simultaneously on ropsten and it works well: https://ropsten.etherscan.io/address/0x6f61D82478F6f0CaabbA8400343b2D52bef27B69