### PR TITLE
Fix `beaconId` derivation

### DIFF
--- a/data/documentation.json
+++ b/data/documentation.json
@@ -5,7 +5,7 @@
         "beaconId": "0xb5087bcd2a04f5653ad8a6b39fa4fb10fabbdec124b8b489b4d8d610e6392198",
         "name": "CoinGecko BTC/USD 0.1 percent deviation",
         "description": "The public CoinGecko BTC/USD price ticker",
-        "templateUrl": "https://github.com/api3dao/operations/blob/ba615b408a779fd66d88abeecb568c3778015bbb/data/apis/api3/templates/coingecko btc_usd.json",
+        "templateUrl": "https://github.com/api3dao/operations/blob/80db72035954845beb7d84988dc815ce109df49a/data/apis/api3/templates/coingecko btc_usd.json",
         "chains": { "ropsten": { "airkeeperDeviationThreshold": 0.1, "airseekerDeviationThreshold": 0.2 } }
       }
     ]

--- a/src/utils/normalization.ts
+++ b/src/utils/normalization.ts
@@ -1,5 +1,4 @@
 import { Buffer } from 'buffer';
-import { defaultAbiCoder, keccak256 } from 'ethers/lib/utils';
 import { ethers } from 'ethers';
 import { decode } from '@api3/airnode-abi';
 import { parse } from 'dotenv';
@@ -15,8 +14,8 @@ export const normalize = (payload: OperationsRepository) => {
 
       const beacons = Object.fromEntries(
         Object.entries(api.beacons).map(([_key, beacon]) => {
-          const beaconId = keccak256(
-            defaultAbiCoder.encode(['address', 'bytes32'], [beacon.airnodeAddress, beacon.templateId])
+          const beaconId = ethers.utils.keccak256(
+            ethers.utils.defaultAbiCoder.encode(['address', 'bytes32'], [beacon.airnodeAddress, beacon.templateId])
           );
 
           return [

--- a/src/utils/normalization.ts
+++ b/src/utils/normalization.ts
@@ -15,7 +15,7 @@ export const normalize = (payload: OperationsRepository) => {
       const beacons = Object.fromEntries(
         Object.entries(api.beacons).map(([_key, beacon]) => {
           const beaconId = ethers.utils.keccak256(
-            ethers.utils.defaultAbiCoder.encode(['address', 'bytes32'], [beacon.airnodeAddress, beacon.templateId])
+            ethers.utils.solidityPack(['address', 'bytes32'], [beacon.airnodeAddress, beacon.templateId])
           );
 
           return [


### PR DESCRIPTION
It appears that the beacon id derivation was incorrect. If you try and use the old beaconIds to read on chain values you'll get an uninitialised beacon.

Please double check @Ashar2shahid 