### PR TITLE
Add publishing changes and development usage notes

### DIFF
--- a/DEVELOPMENT_USAGE.md
+++ b/DEVELOPMENT_USAGE.md
@@ -1,0 +1,143 @@
+# Development Usage Notes
+
+> How to use operations in other projects
+
+Operations is both a directory hierarchy containing metadata related to beacons and also a set of libraries to read,
+validate, normalize, write and manipulate that data.
+
+Common use cases are reading operations as a JSON payload and display that data in a UI in some way.
+
+Below are examples of how to achieve that and a general demonstration of the relationships between data.
+
+### The following commands assume an empty directory and the creation of a project
+
+```shell
+# Initialise the new project
+yarn init
+# You'll be prompted to enter various info about your project
+
+# Install the published operations package
+yarn add @api3/operations
+
+# You may also want Typescript
+yarn add typescript ts-node @types/node -D
+```
+
+Create a demo application file to execute:
+
+```shell
+mkdir scripts
+touch scripts/export.js
+```
+
+Edit scripts/export.js
+
+Import the dependency into your application:
+
+```javascript
+const { readOperationsRepository } = require('@api3/operations/dist/utils/read-operations');
+
+// We'll also import two more Node modules for this demo
+const fs = require('fs');
+const path = require('path');
+```
+
+Read the operations repository into a compound object:
+
+```javascript
+const operations = readOperationsRepository();
+```
+
+Write out the object to a JSON payload: (this file will contain the entirety of operations metadata as a single JSON
+file)
+
+```javascript
+fs.writeFileSync(path.join(__dirname, '../opsexport.json'), JSON.stringify(operations, null, 2));
+```
+
+To list provider names:
+
+```javascript
+console.log(Object.keys(operations.apis));
+```
+
+To list beacons ids on a provider:
+
+```javascript
+console.log(Object.values(operations.apis['amberdata'].beacons).map((beacon) => beacon.beaconId));
+```
+
+To find a beacon by it's ID across all providers:
+
+```javascript
+const beaconIdToFind = '0xc7d143e56da695e6d63f9c408932378e9130486fbb1c2bb8a8a9f74c9bbdf2d2';
+
+const beaconFull = Object.values(operations.apis)
+  .flatMap((api) => Object.values(api.beacons))
+  .find((beacon) => beacon.beaconId === beaconIdToFind);
+
+console.log(beaconFull);
+```
+
+To get the deviation percentage for Airkeeper for a beaconId for chain RSK:
+
+```javascript
+console.log(beaconFull.chains['rsk'].updateConditionPercentage);
+```
+
+To get the template for that beacon:
+
+```javascript
+const templateIdToFind = beaconFull.templateId;
+const templateFull = Object.values(operations.apis)
+  .flatMap((api) => Object.values(api.templates))
+  .find((template) => template.templateId === templateIdToFind);
+
+console.log(templateFull);
+```
+
+EVM chains do not have floating point variable types and therefore all decimal values are stored as whole numbers.
+Airnode multiplies a decimal value from an API endpoint with a `_times` factor. `_times` is an Airnode Reserved
+Parameter. For more information, refer to the [API3 Docs](https://docs.api3.org/ois/v1.0.0/reserved-parameters.html)
+
+To get the multiplication factor in the associated template:
+
+```javascript
+console.log(templateFull.decodedParameters.find((param) => param.name === '_times').value);
+```
+
+To get the logo of an API provider:
+
+```javascript
+console.log(operations.apis['amberdata'].apiMetadata.logoPath);
+```
+
+To get the pretty name of a beacon:
+
+```javascript
+console.log(beaconFull.name);
+```
+
+and the pretty description:
+
+```javascript
+console.log(beaconFull.description);
+```
+
+To print a list of chains and their logos:
+
+```javascript
+console.log(
+  Object.values(operations.chains).map((chain) => ({
+    name: chain.name,
+    logo: chain.logoPath,
+    dapiServer: chain.contracts.DapiServer,
+  }))
+);
+```
+
+Print a list of Dapis (name->beaconId mappings) on Polygon:
+
+```javascript
+console.log(Object.entries(operations.dapis));
+```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > A package that houses data and utilities required for API3 operations
 
+For development usage refer to the [development usage guide](DEVELOPMENT_USAGE.md)
+
 ## Branches and versioning
 
 `main` represents the current state of the system. Deprecated versions are housed in individual branches. Deprecated

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@api3/operations",
   "license": "MIT",
   "private": false,
-  "version": "0.0.1-c",
+  "version": "0.0.1-d",
   "description": "A package to parse API3 operations metadata",
   "main": "./dist/index",
   "types": "./dist/types",
@@ -71,13 +71,12 @@
     "hardhat-deploy": "^0.11.4",
     "husky": "^7.0.4",
     "jest": "^27.4.5",
+    "prettier": "^2.5.1",
     "prompts": "^2.4.2",
     "rimraf": "^3.0.2",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4",
     "zod": "^3.14.2"
   },
-  "dependencies": {
-    "prettier": "^2.5.1"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@api3/operations",
   "license": "MIT",
   "private": false,
-  "version": "0.0.1b",
+  "version": "0.0.1-c",
   "description": "A package to parse API3 operations metadata",
   "main": "./dist/index",
   "types": "./dist/types",
@@ -46,16 +46,16 @@
   },
   "devDependencies": {
     "@api3/airkeeper": "0.0.6",
+    "@api3/airnode-abi": "^0.6.2",
+    "@api3/airnode-admin": "^0.6.2",
+    "@api3/airnode-node": "^0.6.2",
+    "@api3/airnode-ois": "^0.6.2",
+    "@api3/airnode-protocol": "^0.6.2",
     "@api3/airnode-protocol-v1": "0.4.0",
     "@ethersproject/experimental": "5.6.0",
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
-    "@api3/airnode-abi": "^0.6.2",
-    "@api3/airnode-node": "^0.6.2",
-    "@api3/airnode-ois": "^0.6.2",
-    "@api3/airnode-protocol": "^0.6.2",
-    "@api3/airnode-admin": "^0.6.2",
     "@types/node": "^17.0.2",
     "@types/prompts": "^2.0.14",
     "@typescript-eslint/eslint-plugin": "^5.8.0",
@@ -71,12 +71,13 @@
     "hardhat-deploy": "^0.11.4",
     "husky": "^7.0.4",
     "jest": "^27.4.5",
-    "prettier": "^2.5.1",
     "prompts": "^2.4.2",
     "rimraf": "^3.0.2",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4",
     "zod": "^3.14.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "prettier": "^2.5.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,20 @@
 {
   "name": "@api3/operations",
   "license": "MIT",
-  "private": true,
-  "version": "1.0.0",
+  "private": false,
+  "version": "0.0.1b",
+  "description": "A package to parse API3 operations metadata",
   "main": "./dist/index",
   "types": "./dist/types",
   "files": [
-    "dist"
+    "dist",
+    "data",
+    "chain"
   ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "create-boilerplate": "ts-node src/create-boilerplate.ts",
     "create-config": "ts-node src/create-config.ts",
@@ -31,8 +38,7 @@
     "prettier:write": "prettier --write \"./**/*.{js,ts,md,json}\"",
     "pack": "yarn pack",
     "start": "ts-node src/index.ts",
-    "prepare": "husky install",
-    "postinstall": "yarn build"
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * as utils from './utils';
+export * from './constants';


### PR DESCRIPTION
This makes operations publishable and usable by consuming projects.

I also added some much needed development usage guidance (requested by both Warren and Protofire).