### PR TITLE
Add all Beacons to polygon-testnet

### DIFF
--- a/data/apis/amberdata/beacons/amberdata aave_btc.json
+++ b/data/apis/amberdata/beacons/amberdata aave_btc.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata aave_usd.json
+++ b/data/apis/amberdata/beacons/amberdata aave_usd.json
@@ -34,6 +34,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata alpaca_usdt.json
+++ b/data/apis/amberdata/beacons/amberdata alpaca_usdt.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata avax_usd.json
+++ b/data/apis/amberdata/beacons/amberdata avax_usd.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata bnb_usd.json
+++ b/data/apis/amberdata/beacons/amberdata bnb_usd.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata busd_usd.json
+++ b/data/apis/amberdata/beacons/amberdata busd_usd.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 0.4,
       "airseekerConfig": { "deviationThreshold": 0.2, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 0.2, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata cake_usdt.json
+++ b/data/apis/amberdata/beacons/amberdata cake_usdt.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata crv_usd.json
+++ b/data/apis/amberdata/beacons/amberdata crv_usd.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata joe_usd.json
+++ b/data/apis/amberdata/beacons/amberdata joe_usd.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata matic_usd.json
+++ b/data/apis/amberdata/beacons/amberdata matic_usd.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata ooki_eth.json
+++ b/data/apis/amberdata/beacons/amberdata ooki_eth.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata quick_usd.json
+++ b/data/apis/amberdata/beacons/amberdata quick_usd.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata rbtc_btc.json
+++ b/data/apis/amberdata/beacons/amberdata rbtc_btc.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata rbtc_usd.json
+++ b/data/apis/amberdata/beacons/amberdata rbtc_usd.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata usdc_usd.json
+++ b/data/apis/amberdata/beacons/amberdata usdc_usd.json
@@ -24,6 +24,12 @@
       ],
       "updateConditionPercentage": 0.4,
       "airseekerConfig": { "deviationThreshold": 0.2, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 0.2, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata ust_usd.json
+++ b/data/apis/amberdata/beacons/amberdata ust_usd.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 0.4,
       "airseekerConfig": { "deviationThreshold": 0.2, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 0.2, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }

--- a/data/apis/amberdata/beacons/amberdata xvs_usdt.json
+++ b/data/apis/amberdata/beacons/amberdata xvs_usdt.json
@@ -14,6 +14,12 @@
       ],
       "updateConditionPercentage": 2,
       "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
+    },
+    "polygon-testnet": {
+      "active": true,
+      "sponsor": "0xAb770D6E94e26E9388db8d6D10a2458973a7Ff8f",
+      "topUpWallets": [{ "walletType": "API3", "address": "0x25B246C3bA7B7353e286859FaE8913600b96B719" }],
+      "airseekerConfig": { "deviationThreshold": 1, "heartbeatInterval": 86400, "updateInterval": 30 }
     }
   }
 }


### PR DESCRIPTION
Note that `updateConditionPercentage` and the provider-sponsor wallet top up configuration is omitted because we only want the Airseeker to run these.

It's likely that the API3 explorer expects this parameter and will freak out, but it shouldn't display Beacons from chains ending with `-testnet` anyway. Should we tell them this @aquarat ?

We shouldn't merge this until the Airseeker is redeployed. I'm waiting https://github.com/api3dao/airseeker/pull/91 to be merged to do that.