### PR TITLE
Use the mock operations repository for create-boilerplate

### DIFF
--- a/src/create-boilerplate.ts
+++ b/src/create-boilerplate.ts
@@ -1,9 +1,10 @@
+import { join } from 'path';
 import { PromptObject } from 'prompts';
 import { runAndHandleErrors } from './utils/cli';
 import { sanitiseFilename } from './utils/filesystem';
 import { emptyObject } from './utils/normalization';
 import { promptQuestions } from './utils/prompts';
-import { readApiData, readOperationsRepository } from './utils/read-operations';
+import { readOperationsRepository } from './utils/read-operations';
 import { writeOperationsRepository } from './utils/write-operations';
 
 const questions: PromptObject[] = [
@@ -31,7 +32,9 @@ const questions: PromptObject[] = [
 
 const main = async () => {
   const { name, contact, description } = await promptQuestions(questions);
-  const apiDataTemplate = readApiData();
+  // Import the mock operations repository
+  const operationsRepository = readOperationsRepository(join(__dirname, '..', 'test', 'fixtures', 'data'));
+  const apiDataTemplate = operationsRepository.apis.api3;
 
   // Create the boilerplate apiMetadata
   const apiMetadata = emptyObject(apiDataTemplate.apiMetadata, ['active'], []);

--- a/src/utils/read-operations.ts
+++ b/src/utils/read-operations.ts
@@ -17,9 +17,6 @@ interface FilePayload {
 export const readOperationsRepository = (target = join(__dirname, '..', '..', 'data')) =>
   readFileOrDirectoryRecursively(target) as OperationsRepository;
 
-export const readApiData = (target = join(__dirname, '..', '..', 'data', 'apis', 'api3')) =>
-  readFileOrDirectoryRecursively(target);
-
 export const readFileOrDirectoryRecursively = (target: string): any => {
   const stats = statSync(target);
   if (stats.isFile()) {


### PR DESCRIPTION
`create-boilerplate` used to use the api3 folder in the root operations repository. Since that is removed we can use the mock operations repository instead