### PR TITLE
BEC-446: Generates Airnode nodeSettings.stage config value

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/prompts": "^2.0.14",
     "@typescript-eslint/eslint-plugin": "^5.8.0",
     "@typescript-eslint/parser": "^5.8.0",
+    "date-fns": "^2.28.0",
     "dotenv": "^16.0.0",
     "eslint": "^8.5.0",
     "eslint-plugin-functional": "^4.0.2",

--- a/src/create-config.ts
+++ b/src/create-config.ts
@@ -37,6 +37,18 @@ const questions = (choices: Choice[]): PromptObject[] => {
   ];
 };
 
+export const getStageTimestamp = () => {
+  const now = new Date();
+  const year = now.toLocaleString('en-US', { year: '2-digit' });
+  const month = now.toLocaleString('en-US', { month: '2-digit' });
+  const day = now.toLocaleString('en-US', { day: '2-digit' });
+  const hour = now.toLocaleString('en-US', { hour: '2-digit', hour12: false });
+  // const minute = now.toLocaleString('en-US', { minute: '2-digit' }); // doesn't work
+  const minute = now.getMinutes().toLocaleString('en-US', { minimumIntegerDigits: 2, useGrouping: false });
+
+  return `${year}${month}${day}-${hour}${minute}`;
+};
+
 const buildNodeSettings = (
   apiName: string,
   cloudProviderType: string,
@@ -74,7 +86,7 @@ const buildNodeSettings = (
     },
     logFormat: 'plain' as const,
     logLevel: 'INFO' as const,
-    stage: 'dev',
+    stage: `prod-${getStageTimestamp()}`,
     skipValidation: true,
   };
 };

--- a/src/create-config.ts
+++ b/src/create-config.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import { format } from 'date-fns';
 import { Choice, PromptObject } from 'prompts';
 import { encode } from '@api3/airnode-abi';
 import { AirnodeRrpAddresses } from '@api3/airnode-protocol';
@@ -38,15 +39,7 @@ const questions = (choices: Choice[]): PromptObject[] => {
 };
 
 export const getStageTimestamp = () => {
-  const now = new Date();
-  const year = now.toLocaleString('en-US', { year: '2-digit' });
-  const month = now.toLocaleString('en-US', { month: '2-digit' });
-  const day = now.toLocaleString('en-US', { day: '2-digit' });
-  const hour = now.toLocaleString('en-US', { hour: '2-digit', hour12: false });
-  // const minute = now.toLocaleString('en-US', { minute: '2-digit' }); // doesn't work
-  const minute = now.getMinutes().toLocaleString('en-US', { minimumIntegerDigits: 2, useGrouping: false });
-
-  return `${year}${month}${day}-${hour}${minute}`;
+  return format(new Date(), 'yyMMdd-HHmm');
 };
 
 const buildNodeSettings = (

--- a/test/create-config.test.ts
+++ b/test/create-config.test.ts
@@ -2,8 +2,8 @@
 import { join } from 'path';
 import { mkdirSync, rmdirSync } from 'fs';
 import prompts from 'prompts';
+import * as createConfigModule from '../src/create-config';
 import { readOperationsRepository } from '../src/utils/read-operations';
-import { createConfig } from '../src/create-config';
 import { writeOperationsRepository } from '../src/utils/write-operations';
 
 const tempTestPath = join(__dirname, '../temporary_test_folder');
@@ -25,8 +25,10 @@ describe('create-config', () => {
   it('builds the airnode and airkeeper configs for AWS and GCP', async () => {
     const date = new Date().toISOString().split('T')[0];
 
+    jest.spyOn(createConfigModule, 'getStageTimestamp').mockReturnValue('220616-1954');
+
     prompts.inject(['api3', ['aws', 'gcp'], false]);
-    await createConfig(tempTestPath);
+    await createConfigModule.createConfig(tempTestPath);
 
     const newMockOpsRepo = readOperationsRepository(tempTestPath);
     expect(newMockOpsRepo.apis.api3.deployments[date].airnode.aws).toEqual(

--- a/test/fixtures/data/apis/api3/deployments/2022-04-17/airkeeper/aws/config.json
+++ b/test/fixtures/data/apis/api3/deployments/2022-04-17/airkeeper/aws/config.json
@@ -30,7 +30,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.6.5",
-    "stage": "dev",
+    "stage": "prod-220616-1954",
     "skipValidation": true
   },
   "triggers": {

--- a/test/fixtures/data/apis/api3/deployments/2022-04-17/airnode/aws/config.json
+++ b/test/fixtures/data/apis/api3/deployments/2022-04-17/airnode/aws/config.json
@@ -13,7 +13,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.6.5",
-    "stage": "dev",
+    "stage": "prod-220616-1954",
     "skipValidation": true
   },
   "triggers": {

--- a/test/fixtures/data/apis/api3/deployments/2022-04-17/airnode/gcp/config.json
+++ b/test/fixtures/data/apis/api3/deployments/2022-04-17/airnode/gcp/config.json
@@ -18,7 +18,7 @@
     "logFormat": "plain",
     "logLevel": "INFO",
     "nodeVersion": "0.6.5",
-    "stage": "dev",
+    "stage": "prod-220616-1954",
     "skipValidation": true
   },
   "triggers": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3618,6 +3618,11 @@ date-fns@^2.16.1:
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz"
   integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"


### PR DESCRIPTION
Dealing with dates in JS is always challenging 😅. 

This could have easily been implemented in a single line using [moment.js](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format/): `moment().format("YYMMDD-HHmm");` but I remembered that the project is [no longer under active development](https://momentjs.com/docs/#/-project-status/) and ended up deciding that it was not worth using a library just for this small task. 