### PR TITLE
Fix enable policy readers

### DIFF
--- a/data/chains/milkomeda.json
+++ b/data/chains/milkomeda.json
@@ -4,7 +4,7 @@
   "contracts": {
     "DapiServer": "0xC3E76D8829259f2A34541746de2F8A0509Dc1987"
   },
-  "fullName": " Milkomeda",
+  "fullName": "Milkomeda",
   "decimalPlaces": 2,
   "nativeToken": "milkADA",
   "blockTime": 4,

--- a/data/chains/milkomeda.json
+++ b/data/chains/milkomeda.json
@@ -1,0 +1,14 @@
+{
+  "name": "milkomeda",
+  "id": "2001",
+  "contracts": {
+    "DapiServer": "0xC3E76D8829259f2A34541746de2F8A0509Dc1987"
+  },
+  "fullName": " Milkomeda",
+  "decimalPlaces": 2,
+  "nativeToken": "milkADA",
+  "blockTime": 4,
+  "logoPath": "",
+  "testnet": false,
+  "explorerUrl": "https://explorer-mainnet-cardano-evm.c1.milkomeda.com/"
+}

--- a/src/enable-policy-readers.ts
+++ b/src/enable-policy-readers.ts
@@ -71,12 +71,11 @@ const main = async (operationRepositoryTarget?: string) => {
     // TODO define gas strategy in the credentials file
     // Unfortunately we need this script in place immediately, so this is a hack for now.
     // Polygon is seemingly the only network that requires this.
-    enablePoliciesPromises.push(
-      dapiServer.multicall(
-        calldatas,
-        chainName.includes('polygon') ? { gasPrice: await provider.getGasPrice() } : undefined
-      )
-    );
+    if (chainName.includes('polygon')) {
+      enablePoliciesPromises.push(dapiServer.multicall(calldatas, { gasPrice: await provider.getGasPrice() }));
+    } else {
+      enablePoliciesPromises.push(dapiServer.multicall(calldatas));
+    }
   }
 
   const allowedReaderResults = await Promise.allSettled(enablePoliciesPromises);

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -438,6 +438,7 @@ export const chainDeploymentReferencesSchema = z
  * @param endDate The end date of the policy in seconds since the Unix epoch
  * @param ipfsPolicyHash An IPFS hash referencing a document that describes the terms of the coverage policy
  * @param ipfsServicePolicyHash An IPFS hash referencing a document that describes the service policy
+ * @param metadata a metadata string stored on chain as part of the ClaimsManager: https://github.com/api3dao/claims-manager/blob/main/contracts/ClaimsManager.sol#L206
  */
 export const basePolicySchema = z
   .object({
@@ -450,6 +451,7 @@ export const basePolicySchema = z
     endDate: z.number(),
     ipfsPolicyHash: z.string().optional(),
     ipfsServicePolicyHash: z.string().optional(),
+    metadata: z.string().optional(),
   })
   .strict();
 


### PR DESCRIPTION
This fixes enable-policy-readers (workaround for Polygon) and also adds milkomeda.
Milkomeda keeps getting added by normalisation because we have references to it from the deployed chains.