### PR TITLE
Fixes dapiNames by using the hash instead of the encoded dapiName wh…

### DIFF
--- a/src/check-policy-readers.ts
+++ b/src/check-policy-readers.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { Policy } from './types';
 import { runAndHandleErrors } from './utils/cli';
-import { getDapiServerContract } from './utils/evm';
+import { getDapiNameHash, getDapiServerContract } from './utils/evm';
 import { loadCredentials } from './utils/filesystem';
 import { readAndValidateOperationsRepository } from './utils/read-operations';
 
@@ -27,10 +27,10 @@ const main = async (operationRepositoryTarget?: string) => {
           .filter((policy) => Math.floor(Date.now() / 1000) < policy.endDate)
           .map(async ({ dapiName, dataFeedId, readerAddress }) => ({
             chainName,
-            dataFeedId: dapiName ? ethers.utils.formatBytes32String(dapiName) : dataFeedId,
+            dataFeedId,
             readerAddress,
             readerCanReadDataFeed: await dapiServer.readerCanReadDataFeed(
-              dapiName ? ethers.utils.formatBytes32String(dapiName) : dataFeedId,
+              dapiName ? getDapiNameHash(dapiName) : dataFeedId,
               readerAddress
             ),
           }))

--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -10,3 +10,7 @@ export const getDapiServerInterface = () => {
 export const getDapiServerContract = (dapiServerAddress: string, provider: ethers.providers.JsonRpcProvider) => {
   return new ethers.Contract(dapiServerAddress, protocol.DapiServer__factory.abi, provider);
 };
+
+export const getDapiNameHash = (dapiName: any): any => {
+  return ethers.utils.solidityKeccak256(['bytes32'], [ethers.utils.formatBytes32String(dapiName)]);
+};


### PR DESCRIPTION
…en whitelisting a reader

This PR should fail when checking if current policy readers can read api values so then we need to run the script to enable them. Finally merge if all is good.