### PR TITLE
Add webhook call to rebuild the API3 Market

### DIFF
--- a/.github/workflows/cloudflare_pages.yml
+++ b/.github/workflows/cloudflare_pages.yml
@@ -1,0 +1,14 @@
+name: API3 Market Rebuild
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  cloudflare_rebuild_webhook:
+    name: Call Cloudflare Rebuild Webhook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call Cloudflare Rebuild Webhook
+        run: curl -X POST "https://api.cloudflare.com/client/v4/pages/webhooks/deploy_hooks/${{ secrets.CLOUDFLARE_WEBHOOK_UUID }}"


### PR DESCRIPTION
This calls Cloudflare to rebuild the API3 Market whenever someone merges into or pushes to main.

I naturally can't fully test it until it has been merged, ironically.