### PR TITLE
Fix package.json path for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1-d",
   "description": "A package to parse API3 operations metadata",
   "main": "./dist/index",
-  "types": "./dist/types",
+  "types": "./dist/validation/types",
   "files": [
     "dist",
     "data",


### PR DESCRIPTION
This fixes imports using '@api3/operations' in downstream projects.